### PR TITLE
add support for systems running on wifi

### DIFF
--- a/src/main/java/control/Configuration.java
+++ b/src/main/java/control/Configuration.java
@@ -106,8 +106,8 @@ public class Configuration {
 	private static String getBestIPAddress() throws SocketException {		
 		Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
 		for (NetworkInterface netint : Collections.list(nets)) {
-			// get en or eth adapters
-			if (netint.getName().startsWith("e")) {
+			// get wl, en or eth adapters
+			if (netint.getName().startsWith("w") || netint.getName().startsWith("e")) {
 				logger.debug("Found network adapter: " + netint.getName());
 				Enumeration<InetAddress> inetAddresses = netint.getInetAddresses();
 				for (InetAddress inetAddress : Collections.list(inetAddresses)) {


### PR DESCRIPTION
I'm not sure that this check is even necessary, or that this is even a good way to do this, but at least this change makes FBase for people using wifi. Wifi adapters usually start with "wl"

More info about network adapter naming: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/